### PR TITLE
Remove unused import

### DIFF
--- a/2024/03/05/bloke/list.py
+++ b/2024/03/05/bloke/list.py
@@ -1,4 +1,4 @@
-from huggingface_hub import HfApi, ModelFilter
+from huggingface_hub import HfApi
 api = HfApi()
 models = api.list_models()
 models = list(models)


### PR DESCRIPTION
(nit change) `ModelFilter` is unused in the script + it has been deprecated and removed from `huggingface_hub` now (see https://github.com/huggingface/huggingface_hub/issues/2028)